### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 regex
-torch==1.2.0
+torch==1.2.0 @ https://download.pytorch.org/whl/cu100/torch-1.2.0-cp37-cp37m-win_amd64.whlpip ##Install link PyTorch provides installes CUDA 9.2 build. This picks the correct CUDA 10.0 build.
 pyjarowinkler

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 regex
-torch==1.2.0 @ https://download.pytorch.org/whl/cu100/torch-1.2.0-cp37-cp37m-win_amd64.whlpip ##Install link PyTorch provides installes CUDA 9.2 build. This picks the correct CUDA 10.0 build.
+https://download.pytorch.org/whl/cu100/torch-1.2.0-cp37-cp37m-win_amd64.whl ##Torch 1.2.0 CUDA 10.0
 pyjarowinkler


### PR DESCRIPTION
pip install torch==1.2.0 cannot find file. Command recommended via https://pytorch.org/get-started/previous-versions/ installs the CUDA 9.2 version despite saying it would install the CUDA 10.0 version. Link added will path to correct version needed.