### PR TITLE
Import readline, so arrow keys etc. will correctly behave in Linux

### DIFF
--- a/play.py
+++ b/play.py
@@ -6,7 +6,10 @@ import gc
 import random
 import torch
 import textwrap
-import readline
+try:
+	import readline
+except ModuleNotFoundError:
+	pass
 from random import shuffle
 from shutil import get_terminal_size
 

--- a/play.py
+++ b/play.py
@@ -6,6 +6,7 @@ import gc
 import random
 import torch
 import textwrap
+import readline
 from random import shuffle
 from shutil import get_terminal_size
 

--- a/story/utils.py
+++ b/story/utils.py
@@ -5,7 +5,10 @@ import re
 from pyjarowinkler import distance
 import torch
 import random
-import readline
+try:
+	import readline
+except ModuleNotFoundError:
+	pass
 
 from getconfig import logger
 

--- a/story/utils.py
+++ b/story/utils.py
@@ -5,6 +5,7 @@ import re
 from pyjarowinkler import distance
 import torch
 import random
+import readline
 
 from getconfig import logger
 


### PR DESCRIPTION
Without this it seems that at least the arrow keys and home and end keys produce escape sequences when pressed in Linux during prompts, instead of moving the cursor around.