### PR TITLE
Update play.py to handle IOError 13

### DIFF
--- a/play.py
+++ b/play.py
@@ -415,10 +415,15 @@ def play(generator):
                 "-$", "", re.sub("^-", "", re.sub("[^a-zA-Z0-9_-]+", "-", filename))
             )
             if filename != "":
-                with open(
-                    Path("prompts", filename + ".txt"), "w", encoding="utf-8"
-                ) as f:
-                    f.write(context + "\n" + prompt)
+                try:
+                    with open(
+                        Path("prompts", filename + ".txt"), "w", encoding="utf-8"
+                    ) as f:
+                        f.write(context + "\n" + prompt)
+                except IOError:
+                  colPrint(
+                        "Permission error! Unable to write to file.", colors["error"]
+                  )
         else:
             prompt, context = selectFile()
         assert(prompt+context)
@@ -482,8 +487,13 @@ def play(generator):
                         )
                         == "y"
                     ):
-                        with open("config.ini", "w", encoding="utf-8") as file:
-                            config.write(file)
+                        try:
+                          with open("config.ini", "w", encoding="utf-8") as file:
+                              config.write(file)
+                        except IOError:
+                          colPrint(
+                        "Permission error! Changes will not be saved for next session.", colors["error"]
+                          )
                 else:
                     colPrint("Invalid Setting", colors["error"])
                     instructions()

--- a/play.py
+++ b/play.py
@@ -421,9 +421,7 @@ def play(generator):
                     ) as f:
                         f.write(context + "\n" + prompt)
                 except IOError:
-                  colPrint(
-                        "Permission error! Unable to write to file.", colors["error"]
-                  )
+                    colPrint("Permission error! Unable to save custom prompt.", colors["error"])
         else:
             prompt, context = selectFile()
         assert(prompt+context)
@@ -488,12 +486,12 @@ def play(generator):
                         == "y"
                     ):
                         try:
-                          with open("config.ini", "w", encoding="utf-8") as file:
-                              config.write(file)
+                            with open("config.ini", "w", encoding="utf-8") as file:
+                                config.write(file)
                         except IOError:
-                          colPrint(
-                        "Permission error! Changes will not be saved for next session.", colors["error"]
-                          )
+                            colPrint(
+                                "Permission error! Changes will not be saved for next session.", colors["error"]
+                            )
                 else:
                     colPrint("Invalid Setting", colors["error"])
                     instructions()


### PR DESCRIPTION
This update to Play.py will allow it to catch a permission denied (13) IOError when saving a custom prompt or editing config.ini and inform the user before continuing on.
I.e. this crash will now be handled:
![image](https://user-images.githubusercontent.com/58319376/71693121-488d5e00-2d71-11ea-8a80-257ff2b95e6b.png)