### PR TITLE
Fix memory trimming to remove grammatical "that"

### DIFF
--- a/play.py
+++ b/play.py
@@ -598,8 +598,7 @@ def play(generator):
                 elif action == "remember":
                     memory = cmdRegex.group(2).strip()
                     if len(memory) > 0:
-                        memory = memory.strip("that")
-                        memory = memory.strip("That")
+                        memory = re.sub("^[Tt]hat +(.*)", "\\1", memory)
                         memory = memory.strip('.')
                         memory = memory.strip('!')
                         memory = memory.strip('?')


### PR DESCRIPTION
For example: `/remember that something happened` becomes `Something happened.`

We probably don't want to have a lot of repetition in our memory, both for the sake of keeping the prompt size low, and preventing a bit of unnecessary repetition from the AI due to the frequency of words like "that" appearing in the memories. As a result, the remember function is set to trim out a leading "that", and keep only the important details of the sentence.

My first implementation of this has a bug that means that any word that leads with `that` will be pruned of characters until a non-matching character occurs. For example, `the` becomes `e`. This is just a fix of that.