### PR TITLE
Remove pyjarowinkler dependency

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -407,6 +407,7 @@ def mapping_variation_pairs(mapping):
     mapping_list.append((" " + mapping[0] + "\?", " " + mapping[1] + "\?"))
     mapping_list.append((" " + mapping[0] + "\!", " " + mapping[1] + "\!"))
     mapping_list.append((" " + mapping[0] + "\.", " " + mapping[1] + "."))
+    mapping_list.append((" " + mapping[0], " " + mapping[1]))
 
     return mapping_list
 

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,6 @@
 # coding: utf-8
 import re
 
-# TODO: try to get rid of this
-from pyjarowinkler import distance
 import torch
 import random
 import textwrap
@@ -156,14 +154,66 @@ def list_items(items, col=colors['menu'], start=0, end=None):
         output('', end=end)
 
 
-# TODO: get rid if pyjarowinker dependency (AOP) You could use a simpler method, but this has been reported by
-#  RebootTech as a much more accurate way to compare strings. It also helps clean up the history. So it will hurt
-#  ability to check for looping
-def get_similarity(a, b):
-    if len(a) == 0 or len(b) == 0:
-        return 1
-    return distance.get_jaro_distance(a, b, winkler=True, scaling=0.1)
+def _get_prefix(first_string ,second_string):
+	if not first_string or not second_string:
+		return ""
+	if first_string == second_string:
+		return first_string
+	maximum_length = min(len(first_string), len(second_string))
+	for i in range(0, maximum_length):
+		if not first_string[i] == second_string[i]:
+			return first_string[0:i]
+	return first_string[0:maximum_length]
 
+def get_similarity(first_string, second_string, scaling=0.1):
+	first_string_length = len(first_string)
+	second_string_length = len(second_string)
+	a_matches = [False] * first_string_length
+	b_matches = [False] * second_string_length
+	matches = 0
+	transpositions = 0
+	jaro_distance = 0.0
+
+	if first_string_length == 0 or second_string_length == 0:
+		return 1.0
+
+	maximum_matching_distance = (max(first_string_length, second_string_length) // 2) - 1
+	if maximum_matching_distance < 0:
+		maximum_matching_distance = 0
+
+	for i in range (first_string_length):
+		start = max(0, i - maximum_matching_distance)
+		end = min(i + maximum_matching_distance + 1, second_string_length)
+		for x in range (start, end):
+			if b_matches[x]:
+				continue
+			if first_string[i] != second_string[x]:
+				continue
+			a_matches[i] = True
+			b_matches[x] = True
+			matches += 1
+			break
+
+	if matches == 0:
+		return 0.0
+
+	k = 0
+	for i in range(first_string_length):
+		if not a_matches[i]:
+			continue
+		while not b_matches[k]:
+			k += 1
+		if first_string[i] != second_string[k]:
+			transpositions += 1
+		k += 1
+
+	jaro_distance = ((matches / first_string_length) +
+					(matches / second_string_length) +
+					((matches - transpositions / 2) / matches)) / 3.0
+	prefix = min(len(_get_prefix(first_string, second_string)), 4)
+
+    # Round to 2 places of percision to match pyjarowinkler formatting
+	return round((jaro_distance + prefix * scaling * (1.0 - jaro_distance)) * 100.0) / 100.0
 
 def get_num_options(num):
 


### PR DESCRIPTION
Creates new Jaro-Winkler distance function that removes the pyjarowinkler dependency and returns a more accurate distance metric when compared with a [known working Jaro-Winkler implementation](https://stackoverflow.com/a/49854209) per the following set of test cases:
![testCases](https://user-images.githubusercontent.com/58319376/71757355-d729da00-2e5a-11ea-846d-6e40133ecaf7.PNG)

There is a discrepancy when evaluating an extreme difference in case, but the new function is still considerably more accurate and can correctly evaluate a greater range of strings compared to pyjarowinkler.