### PR TITLE
Disable action suggestion

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -59,7 +59,8 @@ log-level = 20
 action-d20 = on
 
 # how many action suggestions to generate, higher is slower
-action-sugg = 3
+# TODO: Change this back to 4 once gpt2_generator.py is refactored
+action-sugg = 0
 
 # How long should the longest suggested actions be? higher is slower. 
 #  Measured in BPE tokens which you can think of as words


### PR DESCRIPTION
Disables suggested actions until a refactor can be done per [cloveranon's recommendation.](http://boards.4channel.org/vg/thread/277185093#p277238150)
Only a temporary thing, but it'll prevent anyone installing the game between now and then from having to turn it off manually (or suffering through it).