### PR TITLE
Add settings menu

### DIFF
--- a/getconfig.py
+++ b/getconfig.py
@@ -22,3 +22,23 @@ logging.basicConfig(
     level=logLevel + oneLevelUp,
 )
 logger.setLevel(logLevel)
+
+"""
+Settings descriptions and their default values keyed by their name.
+These settings, their descriptions, and their defaults appear in the settings menu and the /help prompt.
+"""
+setting_info = {
+    "temp":             ["Higher values make the AI more random.", 0.4],
+    "rep-pen":          ["Controls how repetitive the AI is allowed to be.", 1.2],
+    "text-wrap-width":  ["Maximum width of lines printed by computer.", 80],
+    "console-bell":     ["Beep after AI generates text.", "on"],
+    "top-keks":         ["Number of words the AI can randomly choose.", 20],
+    "action-sugg":      ["How many actions to generate; 0 is off.", 4],
+    "action-d20":       ["Makes actions difficult.", "on"],
+    "action-temp":      ["How random the suggested actions are.", 1],
+    "generate-num":     ["", 60],
+    "top-p":            ["", 0.9],
+    "log-level":        ["", 3],
+}
+
+

--- a/interface.py
+++ b/interface.py
@@ -1,4 +1,5 @@
-from getconfig import settings, colors
+from getconfig import settings, colors, setting_info
+from utils import pad_text
 
 
 def boolValue(bool):
@@ -6,9 +7,8 @@ def boolValue(bool):
 
 
 def instructions():
-    print('\033[' + colors["instructions"]
-		  + 'm\n' +
-          'AID2: Clover Edition Instructions: \n' +
+    print('\033[' + colors["instructions"] + 'm')
+    print('AID2: Clover Edition Instructions: \n' +
           '  Enter actions starting with a verb ex. "go to the tavern" or "attack the orc."\n' +
           '  To speak enter say "(thing you want to say)" or just "(thing you want to say)"\n' +
 		  '  To insert your own text into the story, enter !(thing you want to insert)')
@@ -27,23 +27,7 @@ def instructions():
     print('  "/load"                  Loads a game from a file in the game\'s save directory')
     print('  "/summarize"             Create a new story using by summarizing your previous one')
     print('  "/help"                  Prints these instructions again')
-    print('  "/set [SETTING] [VALUE]" Sets the specified setting to the specified value.:')
-    print('        temp               Higher values make the AI more random. Default: 0.4 | Current:',
-          settings.getfloat("temp"))
-    print('        rep-pen            Controls how repetitive the AI is allowed to be. Default: 1.2 | Current:',
-          settings.getfloat("rep-pen"))
-    print('        text-wrap-width    Maximum width of lines printed by computer. Default: 80 | Current:',
-          settings.getint("text-wrap-width"))
-    print('        console-bell       Beep after AI generates text? Default: on | Current:',
-          boolValue(settings.getboolean("bell")))
-    print('        top-keks           Number of words the AI can randomly choose. Default: 20 | Current:',
-          settings.getint("top-keks"))
-    print('        generate-num       Default: 60 | Current:', settings.getint("generate-num"))
-    print('        top-p              Default: 0.9 | Current:', settings.getfloat("top-p"))
-    print('        log-level          Default: 3 | Current:', settings.getint("log-level"))
-    print('        action-sugg        How many actions to generate, 0 is off. Default: 4 | Current:',
-          settings.getint("action-sugg"))
-    print('        action-d20         Make actions difficult. Default: on | Current:',
-          boolValue(settings.getboolean("action-d20")))
-    print('        action-temp        How random the suggested actions are. Default: 1 | Current:',
-          settings.getfloat("action-temp"), '\033[39m')
+    print('  "/set [SETTING] [VALUE]" Sets the specified setting to the specified value:')
+    for key, val in setting_info.items():
+        print(pad_text("        " + key, 27) + (val[0] + " " if val[0] != "" else "") + "Default: " + str(val[1]))
+    print('\033[39m', end='')

--- a/interface.py
+++ b/interface.py
@@ -27,6 +27,7 @@ def instructions():
     print('  "/load"                  Loads a game from a file in the game\'s save directory')
     print('  "/summarize"             Create a new story using by summarizing your previous one')
     print('  "/help"                  Prints these instructions again')
+    print('  "/settings"              Opens the settings menu')
     print('  "/set [SETTING] [VALUE]" Sets the specified setting to the specified value:')
     for key, val in setting_info.items():
         print(pad_text("        " + key, 27) + (val[0] + " " if val[0] != "" else "") + "Default: " + str(val[1]))

--- a/play.py
+++ b/play.py
@@ -38,8 +38,13 @@ def get_generator():
                     'There are no models in the models directory! You must download a pytorch compatible model!')
             elif len(models) > 1:
                 output("You have multiple models in your models folder. Please select one to load:", 'message')
-                list_items([m.name for m in models], "menu")
-                model = models[input_number(len(models) - 1)]
+                list_items([m.name for m in models] + ["(Exit)"], "menu")
+                model_selection = input_number(len(models))
+                if model_selection == len(models):
+                    output("Exiting. ", "message")
+                    exit(0)
+                else:
+                    model = models[model_selection]
             else:
                 model = models[0]
                 logger.info("Using model: " + str(model))

--- a/play.py
+++ b/play.py
@@ -456,9 +456,9 @@ def play(generator):
                                 cmd_args[0], curr_setting_val, cmd_args[1]
                             )
                         )
-                        settings[cmd_args[0]] = cmd_args[1]
                         output("Saving an invalid option will corrupt file! ", "error")
                         if input_bool("Save setting? (y/N): ", "selection-prompt"):
+                            settings[cmd_args[0]] = cmd_args[1]
                             try:
                                 with open("config.ini", "w", encoding="utf-8") as file:
                                     config.write(file)

--- a/play.py
+++ b/play.py
@@ -203,10 +203,10 @@ def new_story(generator, context, prompt, memory=None, first_result=None):
     return story
 
 
-def save_story(story, savefile_override=""):
+def save_story(story):
     """Saves the existing story to a json file in the saves directory to be resumed later."""
-    savefile = savefile_override or story.savefile
-    while True or not savefile_override:
+    savefile = story.savefile
+    while True:
         print()
         temp_savefile = input_line("Please enter a name for this save: ", "query")
         savefile = savefile if not temp_savefile or len(temp_savefile.strip()) == 0 else temp_savefile
@@ -313,13 +313,13 @@ def alter_text(text):
     return " ".join(sentences).strip()
 
 
-# Prevent reference before assignment
-story = None
-context = None
-prompt = None
-
-
 def play(generator):
+
+    # Prevent reference before assignment
+    story = None
+    context = None
+    prompt = None
+
     print()
 
     with open(Path("interface", "mainTitle.txt"), "r", encoding="utf-8") as file:
@@ -707,8 +707,4 @@ if __name__ == "__main__":
     with open(Path("interface", "clover"), "r", encoding="utf-8") as file:
         print(file.read())
     generator = get_generator()
-    try:
-        play(generator)
-    except:
-        if story is not None:
-            save_story(story, "crash")
+    play(generator)

--- a/play.py
+++ b/play.py
@@ -153,11 +153,10 @@ def settings_menu():
             output(key + ": " + setting_info[key][0], colors["menu"])
             output("Default: " + str(setting_info[key][1]), colors["menu"], beg='')
             output("Current: " + str(settings[key]), colors["menu"], beg='')
-            while True:
-                new_value = input_line("Enter the new value: ", colors["query"], colors["user-text"])
-                if len(new_value.strip()) != 0:
-                    break
-                output("Invalid settings value. ", colors["error"])
+            new_value = input_line("Enter the new value: ", colors["query"], colors["user-text"])
+            if len(new_value.strip()) == 0:
+                output("Invalid value; canceling. ", colors["error"])
+                continue
             output(key + ": " + setting_info[key][0], colors["menu"])
             output("Current: " + str(settings[key]), colors["menu"], beg='')
             output("New: " + str(new_value), colors["menu"], beg='')

--- a/play.py
+++ b/play.py
@@ -155,7 +155,7 @@ def settings_menu():
             output("Current: " + str(settings[key]), colors["menu"], beg='')
             new_value = input_line("Enter the new value: ", colors["query"], colors["user-text"])
             if len(new_value.strip()) == 0:
-                output("Invalid value; canceling. ", colors["error"])
+                output("Invalid value; cancelling. ", colors["error"])
                 continue
             output(key + ": " + setting_info[key][0], colors["menu"])
             output("Current: " + str(settings[key]), colors["menu"], beg='')

--- a/play.py
+++ b/play.py
@@ -56,7 +56,8 @@ def get_generator():
             output("Model could not be loaded. Please try another model. ", "error")
             continue
         except KeyboardInterrupt:
-            output("Model load cancelled. Please select a model to load. ", "message")
+            output("Model load cancelled. ", "error")
+            exit(0)
     return generator
 
 
@@ -202,10 +203,10 @@ def new_story(generator, context, prompt, memory=None, first_result=None):
     return story
 
 
-def save_story(story):
+def save_story(story, savefile_override=""):
     """Saves the existing story to a json file in the saves directory to be resumed later."""
-    savefile = story.savefile
-    while True:
+    savefile = savefile_override or story.savefile
+    while True or not savefile_override:
         print()
         temp_savefile = input_line("Please enter a name for this save: ", "query")
         savefile = savefile if not temp_savefile or len(temp_savefile.strip()) == 0 else temp_savefile
@@ -312,6 +313,12 @@ def alter_text(text):
     return " ".join(sentences).strip()
 
 
+# Prevent reference before assignment
+story = None
+context = None
+prompt = None
+
+
 def play(generator):
     print()
 
@@ -338,11 +345,6 @@ def play(generator):
     output("Go to https://github.com/cloveranon/Clover-Edition/ "
            "or email cloveranon@nuke.africa for bug reports, help, and feature requests.",
            'subsubtitle')
-
-    # Prevent reference before assignment
-    story = None
-    context = None
-    prompt = None
 
     while True:
         # May be needed to avoid out of mem
@@ -705,4 +707,8 @@ if __name__ == "__main__":
     with open(Path("interface", "clover"), "r", encoding="utf-8") as file:
         print(file.read())
     generator = get_generator()
-    play(generator)
+    try:
+        play(generator)
+    except:
+        if story is not None:
+            save_story(story, "crash")

--- a/play.py
+++ b/play.py
@@ -200,7 +200,7 @@ def save_story(story):
     while True:
         print()
         temp_savefile = input_line("Please enter a name for this save: ", "query")
-        savefile = temp_savefile if not temp_savefile or len(temp_savefile.strip()) > 0 else savefile
+        savefile = temp_savefile if not temp_savefile or len(temp_savefile.strip()) == 0 else savefile
         if not savefile or len(savefile.strip()) == 0:
             output("Please enter a valid savefile name. ", "error")
         else:

--- a/play.py
+++ b/play.py
@@ -690,8 +690,5 @@ def play(generator):
 if __name__ == "__main__":
     with open(Path("interface", "clover"), "r", encoding="utf-8") as file:
         print(file.read())
-    instructions()
-    settings_menu()
-    exit(0)
     generator = get_generator()
     play(generator)

--- a/play.py
+++ b/play.py
@@ -346,7 +346,7 @@ def play(generator):
                     "Load a Saved Game",
                     "Change Settings"],
                    'menu')
-        new_game_option = input_number(2)
+        new_game_option = input_number(3)
 
         if new_game_option == 0:
             prompt_file = select_file(Path("prompts"), ".txt")
@@ -354,6 +354,7 @@ def play(generator):
                 context, prompt = load_prompt(prompt_file)
             else:
                 continue
+                
         elif new_game_option == 1:
             with open(
                     Path("interface", "prompt-instructions.txt"), "r", encoding="utf-8"
@@ -377,6 +378,7 @@ def play(generator):
                         f.write(context + "\n" + prompt)
                 except IOError:
                     output("Permission error! Unable to save custom prompt. ", "error")
+
         elif new_game_option == 2:
             story_file = select_file(Path("saves"), ".json")
             if story_file:
@@ -385,6 +387,10 @@ def play(generator):
                     continue
             else:
                 continue
+
+        elif new_game_option == 3:
+            settings_menu()
+            continue
 
         if len((context + prompt).strip()) == 0:
             output("Story has no prompt or context. Please enter a valid custom prompt. ", "error")

--- a/play.py
+++ b/play.py
@@ -196,11 +196,11 @@ def new_story(generator, context, prompt, memory=None, first_result=None):
 
 def save_story(story):
     """Saves the existing story to a json file in the saves directory to be resumed later."""
-    savefile = story.savefile if story.savefile else ""
+    savefile = story.savefile
     while True:
         print()
         temp_savefile = input_line("Please enter a name for this save: ", "query")
-        savefile = temp_savefile if len(temp_savefile.strip()) > 0 else savefile
+        savefile = temp_savefile if not temp_savefile or len(temp_savefile.strip()) > 0 else savefile
         if not savefile or len(savefile.strip()) == 0:
             output("Please enter a valid savefile name. ", "error")
         else:
@@ -225,7 +225,7 @@ def load_story(f):
     with f.open('r', encoding="utf-8") as file:
         try:
             story = Story(generator, "")
-            story.savefile = os.path.splitext(file.name.strip())
+            story.savefile = os.path.splitext(file.name.strip())[0]
             story.from_json(file.read())
             return story, story.context, story.actions[-1] if len(story.actions) > 0 else ""
         except FileNotFoundError:

--- a/storymanager.py
+++ b/storymanager.py
@@ -15,7 +15,7 @@ class Story:
         self.memory = memory
         self.actions = []
         self.results = []
-        self.savefile = None
+        self.savefile = ""
 
     def act(self, action):
         assert (self.context.strip() + action.strip())

--- a/utils.py
+++ b/utils.py
@@ -273,8 +273,9 @@ def list_items(items, col='menu', start=0, end=None, wrap=False):
     """Lists a generic list of items, numbered, starting from the number passed to start. If end is not None,
     an additional element will be added with its name as the value """
     i = start
+    digits = len(str(len(items)-1))
     for s in items:
-        output(str(i) + ") " + s, col, end='', wrap=wrap)
+        output(str(i).rjust(digits) + ") " + s, col, end='', wrap=wrap)
         i += 1
     if end is not None:
         output('', end=end, wrap=wrap)

--- a/utils.py
+++ b/utils.py
@@ -35,6 +35,12 @@ if termWidth < 5:
     termWidth = 999999999
 
 
+def pad_text(text, width, sep=' '):
+    while len(text) < width:
+        text += sep
+    return text
+
+
 def format_result(text):
     """
     Formats the result text from the AI to be more human-readable.


### PR DESCRIPTION
Adds a settings menu which can be used to access the settings from the main menu. Also consolidates the user-modifiable settings into a dict in `getconfig` that maps the settings names to both their description and their default value. This is what's now printed from when the help text appears, in order to make sure the settings menu and help prompt are always consistent. Also adds a `/settings` command to the main game that can be used to access the same menu.

Closes #82 