### PR TITLE
CUDA 11.1 Pytorch to the requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-torch
+-f https://download.pytorch.org/whl/torch_stable.html
+torch==1.8.1+cu111
 https://github.com/finetuneanon/transformers/archive/refs/heads/gpt-neo-dungeon-localattention1.zip


### PR DESCRIPTION
I'm not exactly sure myself if this is the proper way to do it, but I tried to add the -f flag which allows getting CUDA 11.1 enabled Pytorch. It seemed to work for me at least.

I do also want to bring into attention of the install script makers that it might be a good idea to centralize these pip requirements to the requirements.txt which would be called with pip install -r requirements.txt. @Skhmt at least.