### PR TITLE
Split reqs into 3 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Officially we only support local installs. We encourage and recommend installing
 
 To play with GPU acceleration, you need an Nvidia GPU. (Though some anons claim to have gotten it working with on AMD with ROCm) The original "XL" 1558M parameter model requires at least 4GB of VRAM. Smaller models may consume much less. On CPU, response times vary from about a minute on the XL GPT-2 1558M model, which is slow but usable, to about 6 minutes on GPT-Neo.
 
-After either of the following install steps, you must get one of the models.
+After any of the following install steps, you must get one of the models.
 
 ### Windows 10 install
 
-1. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip". Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. Unzip it to a folder.
+1. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip", Unzip it to a folder. Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. 
 2. Go to your Clover Edition folder.
 3. Run `install.bat` and follow the on-screen instructions.
 
@@ -52,10 +52,10 @@ After either of the following install steps, you must get one of the models.
 
 ### Linux install
 
-1. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip", then unzip it to a folder. Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed.
-2. Go to your Clover Edition folder.
-3. Install [Python](https://www.python.org/downloads/) or use your package manager (e.g. `sudo apt-get install python3` or `sudo yum install python3` or something).
-4.. Run `.\install.sh` and follow the on-screen instructions.
+1. Install [Python](https://www.python.org/downloads/) or use your package manager (e.g. `sudo apt-get install python3` or `sudo yum install python3` or something).
+2. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip", then unzip it to a folder. Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed.
+3. Go to your Clover Edition folder.
+4. Run `.\install.sh` and follow the on-screen instructions.
 
 ### OS-agnostic manual install
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Once downloaded, your model folder should look like this:
 
 - Windows: double-click `play.bat`
 - Linux: `venv/bin/python play.py`
+- OS-agnostic install: `python play.py`
 
 
 ## Color support on Windows

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ After either of the following install steps, you must get one of the models.
 
 ### Linux install
 
-1. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip". Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. Unzip it to a folder.
+1. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip", then unzip it to a folder. Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed.
 2. Go to your Clover Edition folder.
 3. Install [Python](https://www.python.org/downloads/) or use your package manager (e.g. `sudo apt-get install python3` or `sudo yum install python3` or something).
 4.. Run `.\install.sh` and follow the on-screen instructions.
@@ -60,12 +60,12 @@ After either of the following install steps, you must get one of the models.
 ### OS-agnostic manual install
 
 1. Install [Python](https://www.python.org/downloads/). The installer should install `pip` and it should add it to your `PATH` automatically. Make sure you have the relevant options selected if the installer gives you any options.
-2. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip". Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. Unzip it to a folder.
+2. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip", then unzip it to a folder. Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. 
 3. Open a command line or terminal and go to your Clover Edition folder.
 4. Run: `pip --no-cache-dir install -r requirements.txt`
 5. Install PyTorch (you must do one of the following):
-    - If you're using an Nvidia GPU with CUDA, run: `pip --no-cache-dir install -r cuda_requirements.txt`
-    - If you're planning on just using your CPU, run: `pip --no-cache-dir install -r cpu_requirements.txt`
+    - If you're using an Nvidia GPU with CUDA, run: `pip install -r cuda_requirements.txt`
+    - If you're planning on just using your CPU, run: `pip install -r cpu_requirements.txt`
 
 
 ## Models

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ After either of the following install steps, you must get one of the models.
 
 ### Windows 10 install
 
-1. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip". Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed.
-2. Run `install.bat` and follow the on-screen instructions.
+1. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip". Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. Unzip it to a folder.
+2. Go to your Clover Edition folder.
+3. Run `install.bat` and follow the on-screen instructions.
 
 #### Windows Troubleshooting
 
@@ -53,13 +54,13 @@ After either of the following install steps, you must get one of the models.
 ### Manual install
 
 1. Install [Python](https://www.python.org/downloads/). The installer should install `pip` and it should add it to your `PATH` automatically. Make sure you have the relevant options selected if the installer gives you any options.
-2. Install PyTorch (aka the `torch` python module.) PyTorch's installation instructions are available [here](https://pytorch.org/get-started/locally/) on their official website. You do not need the `torchvision` nor the `torchaudio` packages.
-    - For Windows or Linux CUDA (Nvidia GPU support), the command will look something like the following: `pip install torch==1.8.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html`
-    - For Windows or Linux with only CPU support, it will look something like: `pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html`
-    - For MacOS users, you just have to: `pip install torch`, as the binaries don't support CUDA and you probably don't have an Nvidia GPU anyway.
-3. Install finetuneanon's Transformers: `pip --no-cache-dir install https://github.com/finetuneanon/transformers/archive/refs/heads/gpt-neo-dungeon-localattention1.zip`
-4. If you're playing on your desktop (i.e. not on Google Colab), install Prompt-Toolkit: `pip install prompt_toolkit`
-5. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip". Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed.
+2. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip". Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. Unzip it to a folder.
+3. Open a command line or terminal and go to your Clover Edition folder.
+4. Run: `pip --no-cache-dir install -r requirements.txt`
+5. Install PyTorch (you must do one of the following):
+    - If you're using an Nvidia GPU with CUDA, run: `pip --no-cache-dir install -r cuda_requirements.txt`
+    - If you're planning on just using your CPU, run: `pip --no-cache-dir install -r cpu_requirements.txt`
+
 
 ## Models
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Also take a look at [AIDungeonPastes](https://aidungeonpastes.github.io/AID2-Art
 * Lots of changes to story history sampling/truncation to hopefully stay on track with longer games
 * Eventually hope to improve the AI itself, but this will take some time
 
-## Install Instructions
+## Install instructions
 ------------------------
 
 Officially we only support local installs. We encourage and recommend installing and running the game locally. However since the beginning most people have been playing it for free on Google's servers through their Colab platform. Allegedly it requires no effort to get started. Try [this link](https://colab.research.google.com/drive/1kYVhVeE6z4sUyyKDVxLGrzI4OTV43eEa) and go to the [4chan threads](https://boards.4chan.org/search#/aidungeon%20OR%20%22ai%20dungeon%22) for help and info.
@@ -45,13 +45,19 @@ After either of the following install steps, you must get one of the models.
 2. Go to your Clover Edition folder.
 3. Run `install.bat` and follow the on-screen instructions.
 
-#### Windows Troubleshooting
+#### Windows troubleshooting
 
 - Users have reported that some anti-virus (specifically Kaspersky) isn't happy with the install.bat script. Please whitelist or temporarily disable anti-virus when installing.
 - You can partially uninstall by deleting the `venv/` folder, and fully uninstall by just deleting the entire Clover Edition folder.
 
+### Linux install
 
-### Manual install
+1. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip". Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. Unzip it to a folder.
+2. Go to your Clover Edition folder.
+3. Install [Python](https://www.python.org/downloads/) or use your package manager (e.g. `sudo apt-get install python3` or `sudo yum install python3` or something).
+4.. Run `.\install.sh` and follow the on-screen instructions.
+
+### OS-agnostic manual install
 
 1. Install [Python](https://www.python.org/downloads/). The installer should install `pip` and it should add it to your `PATH` automatically. Make sure you have the relevant options selected if the installer gives you any options.
 2. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip". Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. Unzip it to a folder.
@@ -99,17 +105,17 @@ Once downloaded, your model folder should look like this:
 Install [Windows Terminal](https://aka.ms/terminal) (recommended) or [cmder](https://cmder.net/) and use that as your terminal.
 
 
-## Datasets and Fine-tuning the AI
+## Datasets and fine-tuning the AI
 ---------------
 
 I threw together a quick page of some tips [here](DATASETS.md). I plan to throw any links to interesting datasets or guides for training and fine-tuning the AI there. Please send me anything interesting.
 
 Fine-tuning is not currently a push button thing and requires some minimal technical ability. Most people are using the program gpt-simple. You may have more luck with the much more advanced [Huggingface-Transformers](https://github.com/huggingface/transformers) program that we use to power Clover-Edition. [This](https://huggingface.co/transformers/examples.html#language-model-fine-tuning) seems to be their documentation on fine-tuning.
 
-## Converting Tensorflow model to Pytorch
+## Converting Tensorflow model to PyTorch
 ----------------
 
-I have made the [convert_gpt2_model.py](convert_gpt2_model.py) script an idiot proof simple way of quickly converting tensorflow models to pytorch models. Just run it on the folder containing a tensorflow model and you will get a pytorch model. You can use the --full flag to get a full 32bit model, but do try 16bit models as they will be potentially half the size for the same accuracy.
+I have made the [convert_gpt2_model.py](convert_gpt2_model.py) script an idiot proof simple way of quickly converting tensorflow models to PyTorch models. Just run it on the folder containing a tensorflow model and you will get a PyTorch model. You can use the --full flag to get a full 32bit model, but do try 16bit models as they will be potentially half the size for the same accuracy.
 
 See the [test-models.py](test-models.py) script to test the accuracy of 16 bit mode if you doubt the chad 16BIT models. My tests were well within expectations:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ After any of the following install steps, you must get one of the models.
 
 ### Windows 10 install
 
-1. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip", Unzip it to a folder. Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. 
+1. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it, select "Download Zip", then unzip it to a folder. Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. 
 2. Go to your Clover Edition folder.
 3. Run `install.bat` and follow the on-screen instructions.
 
@@ -53,14 +53,14 @@ After any of the following install steps, you must get one of the models.
 ### Linux install
 
 1. Install [Python](https://www.python.org/downloads/) or use your package manager (e.g. `sudo apt-get install python3` or `sudo yum install python3` or something).
-2. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip", then unzip it to a folder. Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed.
+2. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it, select "Download Zip", then unzip it to a folder. Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed.
 3. Go to your Clover Edition folder.
-4. Run `.\install.sh` and follow the on-screen instructions.
+4. Run `sh install.sh` and follow the on-screen instructions.
 
 ### OS-agnostic manual install
 
 1. Install [Python](https://www.python.org/downloads/). The installer should install `pip` and it should add it to your `PATH` automatically. Make sure you have the relevant options selected if the installer gives you any options.
-2. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it then select "Download Zip", then unzip it to a folder. Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. 
+2. Download this repo. Github has a green download button to the top right that looks like: `[⤓ Code]`. Click it, select "Download Zip", then unzip it to a folder. Or you can use the git command `git clone --depth=1 "https://github.com/cloveranon/Clover-Edition/"` if you have git installed. 
 3. Open a command line or terminal and go to your Clover Edition folder.
 4. Run: `pip --no-cache-dir install -r requirements.txt`
 5. Install PyTorch (you must do one of the following):
@@ -96,8 +96,8 @@ Once downloaded, your model folder should look like this:
 
 ## Playing
 
-- Windows: `play.bat`
-- Linux: `python play.py`
+- Windows: double-click `play.bat`
+- Linux: `venv/bin/python play.py`
 
 
 ## Color support on Windows

--- a/cpu_requirements.txt
+++ b/cpu_requirements.txt
@@ -1,0 +1,2 @@
+-f https://download.pytorch.org/whl/torch_stable.html
+torch==1.8.1+cpu

--- a/cuda_requirements.txt
+++ b/cuda_requirements.txt
@@ -1,0 +1,2 @@
+-f https://download.pytorch.org/whl/torch_stable.html
+torch==1.8.1+cu111

--- a/install.bat
+++ b/install.bat
@@ -9,12 +9,6 @@ set PythonPathFile=python39._pth
 :: update from https://github.com/microsoft/terminal/releases
 set WindowsTerminalURL=https://github.com/microsoft/terminal/releases/download/v1.7.1091.0/Microsoft.WindowsTerminal_1.7.1091.0_8wekyb3d8bbwe.msixbundle
 
-:: update from https://pytorch.org/get-started/locally/
-set TorchCudaPip=torch==1.8.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html
-
-:: Finetuneanon's fork of Transformers
-set TransformersPip=https://github.com/finetuneanon/transformers/archive/refs/heads/gpt-neo-dungeon-localattention1.zip
-
 :: Checking if the user has curl and tar installed
 for %%X in (curl.exe) do (set HasCurl=%%~$PATH:X)
 for %%X in (tar.exe) do (set HasTar=%%~$PATH:X)
@@ -87,21 +81,17 @@ del get-pip.py
 
 cd ..
 
-:: Install Prompt_Toolkit
-echo Installing Prompt_Toolkit
-%PY% -m pip install prompt_toolkit --no-color --no-warn-script-location
-
-:: Install Transformers
-echo Installing Transformers
-%PY% -m pip --no-cache-dir install %TransformersPip% --no-color --no-warn-script-location
+:: Install Requirements
+echo Installing universal dependencies
+%PY% -m pip --no-cache-dir install -f requirements.txt --no-color --no-warn-script-location
 
 :: Install Torch
 echo Installing PyTorch
 if %usecuda%==1 (
-  %PY% -m pip install %TorchCudaPip% --no-color --no-warn-script-location
+  %PY% -m pip --no-cache-dir install -f cuda_requirements.txt --no-color --no-warn-script-location
 )
 if %usecuda%==2 (
-  %PY% -m pip install torch --no-color --no-warn-script-location
+  %PY% -m pip --no-cache-dir install -f cpu_requirements.txt --no-color --no-warn-script-location
 )
 
 :: Check for and offer to help install Windows Terminal

--- a/install.bat
+++ b/install.bat
@@ -88,10 +88,10 @@ echo Installing universal dependencies
 :: Install Torch
 echo Installing PyTorch
 if %usecuda%==1 (
-  %PY% -m pip --no-cache-dir install -r cuda_requirements.txt --no-color --no-warn-script-location
+  %PY% -m pip install -r cuda_requirements.txt --no-color --no-warn-script-location
 )
 if %usecuda%==2 (
-  %PY% -m pip --no-cache-dir install -r cpu_requirements.txt --no-color --no-warn-script-location
+  %PY% -m pip install -r cpu_requirements.txt --no-color --no-warn-script-location
 )
 
 :: Check for and offer to help install Windows Terminal

--- a/install.bat
+++ b/install.bat
@@ -83,15 +83,15 @@ cd ..
 
 :: Install Requirements
 echo Installing universal dependencies
-%PY% -m pip --no-cache-dir install -f requirements.txt --no-color --no-warn-script-location
+%PY% -m pip --no-cache-dir install -r requirements.txt --no-color --no-warn-script-location
 
 :: Install Torch
 echo Installing PyTorch
 if %usecuda%==1 (
-  %PY% -m pip --no-cache-dir install -f cuda_requirements.txt --no-color --no-warn-script-location
+  %PY% -m pip --no-cache-dir install -r cuda_requirements.txt --no-color --no-warn-script-location
 )
 if %usecuda%==2 (
-  %PY% -m pip --no-cache-dir install -f cpu_requirements.txt --no-color --no-warn-script-location
+  %PY% -m pip --no-cache-dir install -r cpu_requirements.txt --no-color --no-warn-script-location
 )
 
 :: Check for and offer to help install Windows Terminal

--- a/install.sh
+++ b/install.sh
@@ -3,23 +3,6 @@ set -e
 cd "$(dirname "${0}")"
 BASE_DIR="$(pwd)"
 PACKAGES=(aria2 git unzip wget)
-#MIN_PYTHON_VERS="3.4.0"
-
-#version_check () {
-#	MAX_VERS=$(echo -e "$(python3 --version | cut -d' ' -f2)\n$MAX_PYTHON_VERS\n$MIN_PYTHON_VERS"\
-#	| sort -V | tail -n1)
-#	MIN_VERS=$(echo -e "$(python3 --version | cut -d' ' -f2)\n$MAX_PYTHON_VERS\n$MIN_PYTHON_VERS"\
-#	| sort -V | head -n1)
-#	if [ "$MIN_VERS" != "$MIN_PYTHON_VERS" ]; then
-#		echo "Your installed python version, $(python3 --version), is too old."
-#		echo "Please update to at least $MIN_PYTHON_VERS."
-#		exit 1
-#	elif [ "$MAX_VERS" != "$MAX_PYTHON_VERS" ]; then
-#		echo "Your installed python version, $(python3 --version), is too new."
-#		echo "Please install $MAX_PYTHON_VERS."
-#		exit 1
-#	fi
-#}
 
 pip_install () {
 	if [ ! -d "./venv" ]; then
@@ -34,8 +17,15 @@ pip_install () {
 	echo "You are using https://github.com/cloveranon/Clover-Edition/commit/${commit_hash}"
 	source "${BASE_DIR}/venv/bin/activate"
 	pip install --upgrade pip setuptools
-	pip install -r "${BASE_DIR}/requirements.txt"
-	pip install -r "${BASE_DIR}/cuda_requirements.txt"
+	pip --no-cache-dir install -r "${BASE_DIR}/requirements.txt"
+
+	echo "Would you like to install Nvidia CUDA support (~4.5gb) or just use your CPU (~800mb, but much slower)?"
+	select yn in "Nvidia CUDA" "CPU only"; do
+		case $yn in
+			"Nvidia CUDA" ) pip install -r "${BASE_DIR}/cuda_requirements.txt"; break;;
+			"CPU only" ) pip install -r "${BASE_DIR}/cpu_requirements.txt"; break;;
+		esac
+	done
 }
 
 is_command() {

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,7 @@ pip_install () {
 	source "${BASE_DIR}/venv/bin/activate"
 	pip install --upgrade pip setuptools
 	pip install -r "${BASE_DIR}/requirements.txt"
+	pip install -r "${BASE_DIR}/cuda_requirements.txt"
 }
 
 is_command() {

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,1 +1,0 @@
-prompt_toolkit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-torch
+prompt_toolkit
 https://github.com/finetuneanon/transformers/archive/refs/heads/gpt-neo-dungeon-localattention1.zip


### PR DESCRIPTION
To prevent having users downloading 800mb-4.5gb more than they need to, splitting requirements into requirements.txt, cuda_requirements.txt, and cpu_requirements.txt. Requirements.txt has transformers and prompt_toolkit, and the other two have their version of pytorch.

Updates readmes, install.bat, and install.sh to support that.
Removes any references to specific versions besides in the .txt requirements files; each requirement exists in exactly 1 place in the codebase now.

It's a PR because I need someone with linux to double check install.sh (I'm windows-only at home).